### PR TITLE
Feat: Add console games colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Feel free to create a ticket about suggestions, ideas and imporvements.
 - You can deactivated LEDBlinky by setting `is_ledblinky_activated` to `0` in `plugins/ledblinky-integration/config.cmd`
 - You can change the `frontend_default_animation` is `plugins/ledblinky-integration/config.cmd`
 
+## Console Color Rules
+
+_If you have a better idea don't hesitate to create a ticket_
+
+- Shoulder: `White`
+- Trigger: `Brown`
+- Select: `Orange`
+- Start: `Lime`
+
 ## TODO
 
 - Fix a better animation that `random.lwax`, it's very annoying

--- a/plugins/LEDBlinky/LEDBlinkyControls.xml
+++ b/plugins/LEDBlinky/LEDBlinkyControls.xml
@@ -231,6 +231,44 @@
       </player>
     </controlGroup>
   </emulator>
+    <emulator emuname="Sega_CD" emuDesc="Sega CD">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Button A" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="Button B" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Button C" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Button X" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="Button Y" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="Button Z" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Mode" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="Button A" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="Button B" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Button C" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="Button X" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="Button Y" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON6" voice="Button Z" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON6"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" color="Lime" alwaysActive="0" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Mode" color="Orange" alwaysActive="0" inputCodes="JOYCODE_2_SELECT"/>
+      </player>
+    </controlGroup>
+  </emulator>
   <emulator emuname="OTHER" emuDesc="">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0">
       <player number="0">

--- a/plugins/LEDBlinky/LEDBlinkyControls.xml
+++ b/plugins/LEDBlinky/LEDBlinkyControls.xml
@@ -125,17 +125,12 @@
         <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
         <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
       </player>
-    </controlGroup>
-    <controlGroup groupName="mario_kart_64" voice="Mario Kart 64" numPlayers="4" alternating="0" jukebox="0">
-      <player number="0">
-        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" color="White" inputCodes=""/>
-      </player>
       <player number="1">
         <control name="P1_BUTTON1" voice="A" color="Blue" inputCodes="JOYCODE_1_BUTTON1"/>
-        <control name="P1_BUTTON2" voice="B" color="Green" inputCodes="JOYCODE_1_BUTTON2"/>
-        <control name="P1_BUTTON3" voice="Right Shoulder" color="White" inputCodes="JOYCODE_1_BUTTON3"/>
-        <control name="P1_BUTTON4" voice="Left Shoulder" color="White" inputCodes="JOYCODE_1_BUTTON4"/>
-        <control name="P1_BUTTON5" voice="Left Trigger" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON3" voice="B" color="Green" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON5" voice="R" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="L" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_BUTTON7" voice="Z" color="Brown" inputCodes="JOYCODE_1_BUTTON7"/>
         <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
         <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
         <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
@@ -145,10 +140,10 @@
       </player>
       <player number="2">
         <control name="P2_BUTTON1" voice="A" color="Blue" inputCodes="JOYCODE_2_BUTTON1"/>
-        <control name="P2_BUTTON2" voice="B" color="Green" inputCodes="JOYCODE_2_BUTTON2"/>
-        <control name="P2_BUTTON3" voice="Right Shoulder" color="White" inputCodes="JOYCODE_2_BUTTON3"/>
-        <control name="P2_BUTTON4" voice="Left Shoulder" color="White" inputCodes="JOYCODE_2_BUTTON4"/>
-        <control name="P2_BUTTON5" voice="Left Trigger" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON3" voice="B" color="Green" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON5" voice="R" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON6" voice="L" color="White" inputCodes="JOYCODE_2_BUTTON6"/>
+        <control name="P2_BUTTON7" voice="Z" color="Brown" inputCodes="JOYCODE_2_BUTTON7"/>
         <control name="P2_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_UP"/>
         <control name="P2_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_DOWN"/>
         <control name="P2_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_LEFT"/>
@@ -158,10 +153,10 @@
       </player>
       <player number="3">
         <control name="P3_BUTTON1" voice="A" color="Blue" inputCodes="JOYCODE_3_BUTTON1"/>
-        <control name="P3_BUTTON2" voice="B" color="Green" inputCodes="JOYCODE_3_BUTTON2"/>
-        <control name="P3_BUTTON3" voice="Right Shoulder" color="White" inputCodes="JOYCODE_3_BUTTON3"/>
-        <control name="P3_BUTTON4" voice="Left Shoulder" color="White" inputCodes="JOYCODE_3_BUTTON4"/>
-        <control name="P3_BUTTON5" voice="Left Trigger" color="White" inputCodes="JOYCODE_3_BUTTON5"/>
+        <control name="P3_BUTTON3" voice="B" color="Green" inputCodes="JOYCODE_3_BUTTON3"/>
+        <control name="P3_BUTTON5" voice="R" color="White" inputCodes="JOYCODE_3_BUTTON5"/>
+        <control name="P3_BUTTON6" voice="L" color="White" inputCodes="JOYCODE_3_BUTTON6"/>
+        <control name="P3_BUTTON7" voice="Z" color="Brown" inputCodes="JOYCODE_3_BUTTON7"/>
         <control name="P3_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_UP"/>
         <control name="P3_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_DOWN"/>
         <control name="P3_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_LEFT"/>
@@ -171,16 +166,162 @@
       </player>
       <player number="4">
         <control name="P4_BUTTON1" voice="A" color="Blue" inputCodes="JOYCODE_4_BUTTON1"/>
-        <control name="P4_BUTTON2" voice="B" color="Green" inputCodes="JOYCODE_4_BUTTON2"/>
-        <control name="P4_BUTTON3" voice="Right Shoulder" color="White" inputCodes="JOYCODE_4_BUTTON3"/>
-        <control name="P4_BUTTON4" voice="Left Shoulder" color="White" inputCodes="JOYCODE_4_BUTTON4"/>
-        <control name="P4_BUTTON5" voice="Left Trigger" color="White" inputCodes="JOYCODE_4_BUTTON5"/>
+        <control name="P4_BUTTON3" voice="B" color="Green" inputCodes="JOYCODE_4_BUTTON3"/>
+        <control name="P4_BUTTON5" voice="R" color="White" inputCodes="JOYCODE_4_BUTTON5"/>
+        <control name="P4_BUTTON6" voice="L" color="White" inputCodes="JOYCODE_4_BUTTON6"/>
+        <control name="P4_BUTTON7" voice="Z" color="Brown" inputCodes="JOYCODE_4_BUTTON7"/>
         <control name="P4_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_UP"/>
         <control name="P4_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_DOWN"/>
         <control name="P4_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_LEFT"/>
         <control name="P4_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_RIGHT"/>
         <control name="P4_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_START"/>
         <control name="P4_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_SELECT"/>
+      </player>
+    </controlGroup>
+  </emulator>
+  <emulator emuname="Nintendo_GameCube" emuDesc="Nintendo GameCube Console">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="4" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="B" color="Red" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="A" color="Green" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Y" color="Black" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="X" color="Black" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="Z" color="Blue" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON7" voice="R" color="Brown" inputCodes="JOYCODE_1_BUTTON7"/>
+        <control name="P1_BUTTON8" voice="L" color="Brown" inputCodes="JOYCODE_1_BUTTON8"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="B" color="Red" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="A" color="Green" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Y" color="Black" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="X" color="Black" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="Z" color="Blue" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON7" voice="R" color="Brown" inputCodes="JOYCODE_2_BUTTON7"/>
+        <control name="P2_BUTTON8" voice="L" color="Brown" inputCodes="JOYCODE_2_BUTTON8"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_SELECT"/>
+      </player>
+      <player number="3">
+        <control name="P3_BUTTON1" voice="B" color="Red" inputCodes="JOYCODE_3_BUTTON1"/>
+        <control name="P3_BUTTON2" voice="A" color="Green" inputCodes="JOYCODE_3_BUTTON2"/>
+        <control name="P3_BUTTON3" voice="Y" color="Black" inputCodes="JOYCODE_3_BUTTON3"/>
+        <control name="P3_BUTTON4" voice="X" color="Black" inputCodes="JOYCODE_3_BUTTON4"/>
+        <control name="P3_BUTTON5" voice="Z" color="Blue" inputCodes="JOYCODE_3_BUTTON5"/>
+        <control name="P3_BUTTON7" voice="R" color="Brown" inputCodes="JOYCODE_3_BUTTON7"/>
+        <control name="P3_BUTTON8" voice="L" color="Brown" inputCodes="JOYCODE_3_BUTTON8"/>
+        <control name="P3_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_UP"/>
+        <control name="P3_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_DOWN"/>
+        <control name="P3_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_LEFT"/>
+        <control name="P3_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_RIGHT"/>
+        <control name="P3_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_START"/>
+        <control name="P3_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_SELECT"/>
+      </player>
+      <player number="4">
+        <control name="P4_BUTTON1" voice="B" color="Red" inputCodes="JOYCODE_4_BUTTON1"/>
+        <control name="P4_BUTTON2" voice="A" color="Green" inputCodes="JOYCODE_4_BUTTON2"/>
+        <control name="P4_BUTTON3" voice="Y" color="Black" inputCodes="JOYCODE_4_BUTTON3"/>
+        <control name="P4_BUTTON4" voice="X" color="Black" inputCodes="JOYCODE_4_BUTTON4"/>
+        <control name="P4_BUTTON5" voice="Z" color="Blue" inputCodes="JOYCODE_4_BUTTON5"/>
+        <control name="P4_BUTTON7" voice="R" color="Brown" inputCodes="JOYCODE_4_BUTTON7"/>
+        <control name="P4_BUTTON8" voice="L" color="Brown" inputCodes="JOYCODE_4_BUTTON8"/>
+        <control name="P4_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_UP"/>
+        <control name="P4_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_DOWN"/>
+        <control name="P4_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_LEFT"/>
+        <control name="P4_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_RIGHT"/>
+        <control name="P4_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_START"/>
+        <control name="P4_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_SELECT"/>
+      </player>
+    </controlGroup>
+  </emulator>
+  <emulator emuname="Super_Nintendo_Entertainment_System" emuDesc="" romDefaultNameVoice="0" ignoreGameQuitCommand="0" emulatorIsMAME="0">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="B" alwaysActive="0" color="Purple" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="A" alwaysActive="0" color="Purple" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Y" alwaysActive="0" color="Cyan" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="X" alwaysActive="0" color="Cyan" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="R" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="L" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="B" alwaysActive="0" color="Purple" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="A" alwaysActive="0" color="Purple" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Y" alwaysActive="0" color="Cyan" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="X" alwaysActive="0" color="Cyan" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="R" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON6" voice="L" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON6"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_2_SELECT"/>
+      </player>
+    </controlGroup>
+  </emulator>
+   <emulator emuname="Sega_Dreamcast" emuDesc="Sega Dreamcast">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="XBOX 3 60 Controller" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="B" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="A" alwaysActive="0" color="Blue" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Y" alwaysActive="0" color="Yellow" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="X" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON7" voice="R" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON7"/>
+        <control name="P1_BUTTON8" voice="L" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON8"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="B" alwaysActive="0" color="Red" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="A" alwaysActive="0" color="Blue" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Y" alwaysActive="0" color="Yellow" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="X" alwaysActive="0" color="Green" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON7" voice="R" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON7"/>
+        <control name="P2_BUTTON8" voice="L" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON8"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_2_SELECT"/>
       </player>
     </controlGroup>
   </emulator>
@@ -193,12 +334,12 @@
         <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
       </player>
       <player number="1">
-        <control name="P1_BUTTON1" voice="Button A" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON1"/>
-        <control name="P1_BUTTON2" voice="Button B" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON2"/>
-        <control name="P1_BUTTON3" voice="Button C" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON3"/>
-        <control name="P1_BUTTON4" voice="Button X" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON4"/>
-        <control name="P1_BUTTON5" voice="Button Y" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
-        <control name="P1_BUTTON6" voice="Button Z" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_BUTTON1" voice="A" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="B" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="C" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="X" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="Y" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="Z" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
         <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
         <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
         <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
@@ -207,12 +348,50 @@
         <control name="P1_BUTTON10" voice="Mode" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
       </player>
       <player number="2">
-        <control name="P2_BUTTON1" voice="Button A" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON1"/>
-        <control name="P2_BUTTON2" voice="Button B" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON2"/>
-        <control name="P2_BUTTON3" voice="Button C" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON3"/>
-        <control name="P2_BUTTON4" voice="Button X" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON4"/>
-        <control name="P2_BUTTON5" voice="Button Y" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
-        <control name="P2_BUTTON6" voice="Button Z" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON6"/>
+        <control name="P2_BUTTON1" voice="A" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="B" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="C" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="X" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="Y" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON6" voice="Z" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON6"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" color="Lime" alwaysActive="0" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Mode" color="Orange" alwaysActive="0" inputCodes="JOYCODE_2_SELECT"/>
+      </player>
+    </controlGroup>
+  </emulator>
+  <emulator emuname="Sega_Genesis" emuDesc="Sega Genesis / Megadrive">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="A" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="B" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="C" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="X" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="Y" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="Z" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Mode" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="A" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="B" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="C" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="X" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="Y" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON6" voice="Z" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON6"/>
         <control name="P2_JOYSTICK_UP" voice="Up" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_UP"/>
         <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
         <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
@@ -352,28 +531,28 @@
         <control name="CONTROL_JOY8WAY" voice="8-way Joystick" color="" primaryControl="1"/>
       </player>
       <player number="1">
-        <control name="P1_BUTTON1" voice="Button 1" color="" inputCodes=""/>
-        <control name="P1_BUTTON2" voice="Button 2" color="" inputCodes=""/>
-        <control name="P1_BUTTON3" voice="Button 3" color="" inputCodes=""/>
-        <control name="P1_BUTTON4" voice="Button 4" color="" inputCodes=""/>
-        <control name="P1_BUTTON5" voice="Button 5" color="" inputCodes=""/>
-        <control name="P1_BUTTON6" voice="Button 6" color="" inputCodes=""/>
-        <control name="P1_BUTTON7" voice="Button 7" color="" inputCodes=""/>
-        <control name="P1_BUTTON8" voice="Button 8" color="" inputCodes=""/>
+        <control name="P1_BUTTON1" voice="1" color="" inputCodes=""/>
+        <control name="P1_BUTTON2" voice="2" color="" inputCodes=""/>
+        <control name="P1_BUTTON3" voice="3" color="" inputCodes=""/>
+        <control name="P1_BUTTON4" voice="4" color="" inputCodes=""/>
+        <control name="P1_BUTTON5" voice="5" color="" inputCodes=""/>
+        <control name="P1_BUTTON6" voice="6" color="" inputCodes=""/>
+        <control name="P1_BUTTON7" voice="7" color="" inputCodes=""/>
+        <control name="P1_BUTTON8" voice="8" color="" inputCodes=""/>
         <control name="P1_JOYSTICK_UP" voice="Up" color="" inputCodes=""/>
         <control name="P1_JOYSTICK_DOWN" voice="Down" color="" inputCodes=""/>
         <control name="P1_JOYSTICK_LEFT" voice="Left" color="" inputCodes=""/>
         <control name="P1_JOYSTICK_RIGHT" voice="Right" color="" inputCodes=""/>
       </player>
       <player number="2">
-        <control name="P2_BUTTON1" voice="Button 1" color="" inputCodes=""/>
-        <control name="P2_BUTTON2" voice="Button 2" color="" inputCodes=""/>
-        <control name="P2_BUTTON3" voice="Button 3" color="" inputCodes=""/>
-        <control name="P2_BUTTON4" voice="Button 4" color="" inputCodes=""/>
-        <control name="P2_BUTTON5" voice="Button 5" color="" inputCodes=""/>
-        <control name="P2_BUTTON6" voice="Button 6" color="" inputCodes=""/>
-        <control name="P2_BUTTON7" voice="Button 7" color="" inputCodes=""/>
-        <control name="P2_BUTTON8" voice="Button 8" color="" inputCodes=""/>
+        <control name="P2_BUTTON1" voice="1" color="" inputCodes=""/>
+        <control name="P2_BUTTON2" voice="2" color="" inputCodes=""/>
+        <control name="P2_BUTTON3" voice="3" color="" inputCodes=""/>
+        <control name="P2_BUTTON4" voice="4" color="" inputCodes=""/>
+        <control name="P2_BUTTON5" voice="5" color="" inputCodes=""/>
+        <control name="P2_BUTTON6" voice="6" color="" inputCodes=""/>
+        <control name="P2_BUTTON7" voice="7" color="" inputCodes=""/>
+        <control name="P2_BUTTON8" voice="8" color="" inputCodes=""/>
         <control name="P2_JOYSTICK_UP" voice="Up" color="" inputCodes=""/>
         <control name="P2_JOYSTICK_DOWN" voice="Down" color="" inputCodes=""/>
         <control name="P2_JOYSTICK_LEFT" voice="Left" color="" inputCodes=""/>

--- a/plugins/LEDBlinky/LEDBlinkyControls.xml
+++ b/plugins/LEDBlinky/LEDBlinkyControls.xml
@@ -72,6 +72,120 @@
       </player>
     </controlGroup>
   </emulator>
+  <emulator emuname="Nintendo_64" emuDesc="Nintendo 64 Console">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="4" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+    </controlGroup>
+    <controlGroup groupName="mario_kart_64" voice="Mario Kart 64" numPlayers="4" alternating="0" jukebox="0">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" color="White" inputCodes=""/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="A" color="Blue" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="B" color="Green" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Right Shoulder" color="White" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Left Shoulder" color="White" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="Left Trigger" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="A" color="Blue" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="B" color="Green" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Right Shoulder" color="White" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="Left Shoulder" color="White" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="Left Trigger" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_SELECT"/>
+      </player>
+      <player number="3">
+        <control name="P3_BUTTON1" voice="A" color="Blue" inputCodes="JOYCODE_3_BUTTON1"/>
+        <control name="P3_BUTTON2" voice="B" color="Green" inputCodes="JOYCODE_3_BUTTON2"/>
+        <control name="P3_BUTTON3" voice="Right Shoulder" color="White" inputCodes="JOYCODE_3_BUTTON3"/>
+        <control name="P3_BUTTON4" voice="Left Shoulder" color="White" inputCodes="JOYCODE_3_BUTTON4"/>
+        <control name="P3_BUTTON5" voice="Left Trigger" color="White" inputCodes="JOYCODE_3_BUTTON5"/>
+        <control name="P3_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_UP"/>
+        <control name="P3_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_DOWN"/>
+        <control name="P3_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_LEFT"/>
+        <control name="P3_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_RIGHT"/>
+        <control name="P3_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_START"/>
+        <control name="P3_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_3_SELECT"/>
+      </player>
+      <player number="4">
+        <control name="P4_BUTTON1" voice="A" color="Blue" inputCodes="JOYCODE_4_BUTTON1"/>
+        <control name="P4_BUTTON2" voice="B" color="Green" inputCodes="JOYCODE_4_BUTTON2"/>
+        <control name="P4_BUTTON3" voice="Right Shoulder" color="White" inputCodes="JOYCODE_4_BUTTON3"/>
+        <control name="P4_BUTTON4" voice="Left Shoulder" color="White" inputCodes="JOYCODE_4_BUTTON4"/>
+        <control name="P4_BUTTON5" voice="Left Trigger" color="White" inputCodes="JOYCODE_4_BUTTON5"/>
+        <control name="P4_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_UP"/>
+        <control name="P4_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_DOWN"/>
+        <control name="P4_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_LEFT"/>
+        <control name="P4_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_RIGHT"/>
+        <control name="P4_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_START"/>
+        <control name="P4_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_SELECT"/>
+      </player>
+    </controlGroup>
+  </emulator>
+  <emulator emuname="Sony_Playstation" emuDesc="PSX">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Cross" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="Circle" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Triangle" alwaysActive="0" color="Blue" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Square" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="R1" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="L1" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_BUTTON7" voice="R2" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON7"/>
+        <control name="P1_BUTTON8" voice="L2" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON8"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="Cross" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="Circle" alwaysActive="0" color="Green" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Triangle" alwaysActive="0" color="Blue" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="Square" alwaysActive="0" color="Red" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="R1" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON6" voice="L1" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON6"/>
+        <control name="P2_BUTTON7" voice="R2" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON7"/>
+        <control name="P2_BUTTON8" voice="L2" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON8"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_SELECT"/>
+      </player>
+    </controlGroup>
+    <controlGroup groupName="crash_bandicoot_2_-_cortex_strikes_back_(usa)" voice="Crash Bandicoot 2 - Cortex Strikes Back (USA)" numPlayers="1" alternating="0" jukebox="0">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" color="White" inputCodes=""/>
+      </player>
+    </controlGroup>
+  </emulator>
   <emulator emuname="OTHER" emuDesc="">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0">
       <player number="0">

--- a/plugins/LEDBlinky/LEDBlinkyControls.xml
+++ b/plugins/LEDBlinky/LEDBlinkyControls.xml
@@ -72,6 +72,52 @@
       </player>
     </controlGroup>
   </emulator>
+  <emulator emuname="Commodore_64" emuDesc="">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" jukebox="0" ledwizGlobalPulse="3" defaultActive="48,48,48,48" defaultInactive="0,0,0,0">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Fire Button" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="Fire Button" color="Red" alwaysActive="0" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_RIGHT"/>
+      </player>
+    </controlGroup>
+    <controlGroup groupName="uridium" voice="Uridium" numPlayers="1" alternating="0" jukebox="0" ledwizGlobalPulse="3" defaultActive="48,48,48,48" defaultInactive="0,0,0,0">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Fire Button" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="Fire Button" color="Red" alwaysActive="0" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_RIGHT"/>
+      </player>
+    </controlGroup>
+  </emulator>
   <emulator emuname="Nintendo_64" emuDesc="Nintendo 64 Console">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="4" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
       <player number="0">
@@ -136,6 +182,44 @@
         <control name="P4_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_RIGHT"/>
         <control name="P4_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_START"/>
         <control name="P4_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_4_SELECT"/>
+      </player>
+    </controlGroup>
+  </emulator>
+  <emulator emuname="Sega_CD" emuDesc="Sega CD">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Button A" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="Button B" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Button C" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Button X" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="Button Y" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="Button Z" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Mode" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="Button A" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="Button B" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Button C" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="Button X" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="Button Y" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON6" voice="Button Z" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON6"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" color="Lime" alwaysActive="0" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Mode" color="Orange" alwaysActive="0" inputCodes="JOYCODE_2_SELECT"/>
       </player>
     </controlGroup>
   </emulator>
@@ -207,7 +291,7 @@
       </player>
     </controlGroup>
   </emulator>
-    <emulator emuname="Sony_PSP" emuDesc="PSP">
+  <emulator emuname="Sony_PSP" emuDesc="PSP">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="1" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
       <player number="0">
         <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
@@ -228,44 +312,6 @@
         <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
         <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
         <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
-      </player>
-    </controlGroup>
-  </emulator>
-    <emulator emuname="Sega_CD" emuDesc="Sega CD">
-    <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
-      <player number="0">
-        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
-        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
-        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
-        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
-      </player>
-      <player number="1">
-        <control name="P1_BUTTON1" voice="Button A" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON1"/>
-        <control name="P1_BUTTON2" voice="Button B" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON2"/>
-        <control name="P1_BUTTON3" voice="Button C" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON3"/>
-        <control name="P1_BUTTON4" voice="Button X" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON4"/>
-        <control name="P1_BUTTON5" voice="Button Y" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
-        <control name="P1_BUTTON6" voice="Button Z" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
-        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
-        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
-        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
-        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
-        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
-        <control name="P1_BUTTON10" voice="Mode" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
-      </player>
-      <player number="2">
-        <control name="P2_BUTTON1" voice="Button A" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON1"/>
-        <control name="P2_BUTTON2" voice="Button B" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON2"/>
-        <control name="P2_BUTTON3" voice="Button C" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON3"/>
-        <control name="P2_BUTTON4" voice="Button X" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON4"/>
-        <control name="P2_BUTTON5" voice="Button Y" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
-        <control name="P2_BUTTON6" voice="Button Z" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON6"/>
-        <control name="P2_JOYSTICK_UP" voice="Up" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_UP"/>
-        <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
-        <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
-        <control name="P2_JOYSTICK_RIGHT" voice="Right" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_RIGHT"/>
-        <control name="P2_BUTTON9" voice="Start" color="Lime" alwaysActive="0" inputCodes="JOYCODE_2_START"/>
-        <control name="P2_BUTTON10" voice="Mode" color="Orange" alwaysActive="0" inputCodes="JOYCODE_2_SELECT"/>
       </player>
     </controlGroup>
   </emulator>

--- a/plugins/LEDBlinky/LEDBlinkyControls.xml
+++ b/plugins/LEDBlinky/LEDBlinkyControls.xml
@@ -147,42 +147,63 @@
         <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
         <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
       </player>
+    </controlGroup>
+    <controlGroup groupName="crash_bandicoot_2_-_cortex_strikes_back_(usa)" voice="Crash Bandicoot 2 - Cortex Strikes Back (USA)" numPlayers="1" alternating="0" jukebox="0">
       <player number="1">
-        <control name="P1_BUTTON1" voice="Cross" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_1_BUTTON1"/>
-        <control name="P1_BUTTON2" voice="Circle" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON2"/>
-        <control name="P1_BUTTON3" voice="Triangle" alwaysActive="0" color="Blue" inputCodes="JOYCODE_1_BUTTON3"/>
-        <control name="P1_BUTTON4" voice="Square" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON4"/>
-        <control name="P1_BUTTON5" voice="R1" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON5"/>
-        <control name="P1_BUTTON6" voice="L1" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON6"/>
-        <control name="P1_BUTTON7" voice="R2" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON7"/>
-        <control name="P1_BUTTON8" voice="L2" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_BUTTON8"/>
+        <control name="P1_BUTTON1" voice="Cross" alwaysActive="0" color="Blue" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="Circle" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Triangle" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Square" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="R1" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
         <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
         <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
         <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
         <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
-        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_START"/>
-        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_SELECT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+    </controlGroup>
+    <controlGroup groupName="castlevania_-_symphony_of_the_night" voice="Castlevania - Symphony Of The Night" numPlayers="1" alternating="0" jukebox="0">
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Cross" alwaysActive="0" color="Blue" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="Circle" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Triangle" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Square" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="R1" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="L1" alwaysActive="0" color="Brown" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_BUTTON7" voice="R2" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON7"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+    </controlGroup>
+    <controlGroup groupName="tekken_3_(usa)" voice="Tekken 3 (USA)" numPlayers="2" alternating="0" jukebox="0">
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Cross" alwaysActive="0" color="Blue" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="Circle" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Triangle" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Square" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
       </player>
       <player number="2">
-        <control name="P2_BUTTON1" voice="Cross" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_2_BUTTON1"/>
-        <control name="P2_BUTTON2" voice="Circle" alwaysActive="0" color="Green" inputCodes="JOYCODE_2_BUTTON2"/>
-        <control name="P2_BUTTON3" voice="Triangle" alwaysActive="0" color="Blue" inputCodes="JOYCODE_2_BUTTON3"/>
-        <control name="P2_BUTTON4" voice="Square" alwaysActive="0" color="Red" inputCodes="JOYCODE_2_BUTTON4"/>
-        <control name="P2_BUTTON5" voice="R1" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON5"/>
-        <control name="P2_BUTTON6" voice="L1" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON6"/>
-        <control name="P2_BUTTON7" voice="R2" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON7"/>
-        <control name="P2_BUTTON8" voice="L2" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_BUTTON8"/>
+        <control name="P2_BUTTON1" voice="Cross" alwaysActive="0" color="Blue" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="Circle" alwaysActive="0" color="Red" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Triangle" alwaysActive="0" color="Green" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="Square" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_2_BUTTON4"/>
         <control name="P2_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_UP"/>
         <control name="P2_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_DOWN"/>
         <control name="P2_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_LEFT"/>
         <control name="P2_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_RIGHT"/>
-        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_START"/>
-        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_SELECT"/>
-      </player>
-    </controlGroup>
-    <controlGroup groupName="crash_bandicoot_2_-_cortex_strikes_back_(usa)" voice="Crash Bandicoot 2 - Cortex Strikes Back (USA)" numPlayers="1" alternating="0" jukebox="0">
-      <player number="0">
-        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" color="White" inputCodes=""/>
+        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_2_SELECT"/>
       </player>
     </controlGroup>
   </emulator>

--- a/plugins/LEDBlinky/LEDBlinkyControls.xml
+++ b/plugins/LEDBlinky/LEDBlinkyControls.xml
@@ -207,6 +207,30 @@
       </player>
     </controlGroup>
   </emulator>
+    <emulator emuname="Sony_PSP" emuDesc="PSP">
+    <controlGroup groupName="DEFAULT" voice="" numPlayers="1" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
+      <player number="0">
+        <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
+        <control name="UI_CANCEL" voice="" alwaysActive="1" color="Red" inputCodes="KEY_EXITGAME"/>
+        <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
+        <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
+      </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Cross" alwaysActive="0" color="Blue" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="Circle" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Triangle" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Square" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="R" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="L" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+    </controlGroup>
+  </emulator>
   <emulator emuname="OTHER" emuDesc="">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0">
       <player number="0">

--- a/plugins/LEDBlinky/LEDBlinkyControls.xml
+++ b/plugins/LEDBlinky/LEDBlinkyControls.xml
@@ -86,6 +86,8 @@
         <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
         <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
         <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
       </player>
       <player number="2">
         <control name="P2_BUTTON1" voice="Fire Button" color="Red" alwaysActive="0" inputCodes="JOYCODE_2_BUTTON1"/>
@@ -93,6 +95,8 @@
         <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
         <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
         <control name="P2_JOYSTICK_RIGHT" voice="Right" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_2_SELECT"/>
       </player>
     </controlGroup>
     <controlGroup groupName="uridium" voice="Uridium" numPlayers="1" alternating="0" jukebox="0" ledwizGlobalPulse="3" defaultActive="48,48,48,48" defaultInactive="0,0,0,0">
@@ -108,13 +112,8 @@
         <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
         <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
         <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
-      </player>
-      <player number="2">
-        <control name="P2_BUTTON1" voice="Fire Button" color="Red" alwaysActive="0" inputCodes="JOYCODE_2_BUTTON1"/>
-        <control name="P2_JOYSTICK_UP" voice="Up" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_UP"/>
-        <control name="P2_JOYSTICK_DOWN" voice="Down" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_DOWN"/>
-        <control name="P2_JOYSTICK_LEFT" voice="Left" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_LEFT"/>
-        <control name="P2_JOYSTICK_RIGHT" voice="Right" color="Black" alwaysActive="0" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
       </player>
     </controlGroup>
   </emulator>
@@ -231,6 +230,38 @@
         <control name="UI_PAUSE" voice="" alwaysActive="1" color="Yellow" inputCodes="KEY_RLPAUSE|KEY_MAMEPAUSE"/>
         <control name="UI_SELECT" voice="" alwaysActive="1" color="Green" inputCodes="KEY_SELECTKEY"/>
       </player>
+      <player number="1">
+        <control name="P1_BUTTON1" voice="Cross" alwaysActive="0" color="Blue" inputCodes="JOYCODE_1_BUTTON1"/>
+        <control name="P1_BUTTON2" voice="Circle" alwaysActive="0" color="Red" inputCodes="JOYCODE_1_BUTTON2"/>
+        <control name="P1_BUTTON3" voice="Triangle" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON3"/>
+        <control name="P1_BUTTON4" voice="Square" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_1_BUTTON4"/>
+        <control name="P1_BUTTON5" voice="R1" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
+        <control name="P1_BUTTON6" voice="L1" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_BUTTON7" voice="R2" alwaysActive="0" color="Brown" inputCodes="JOYCODE_1_BUTTON7"/>
+        <control name="P1_BUTTON8" voice="L2" alwaysActive="0" color="Brown" inputCodes="JOYCODE_1_BUTTON8"/>
+        <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
+        <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
+        <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>
+        <control name="P1_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_RIGHT"/>
+        <control name="P1_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_1_START"/>
+        <control name="P1_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_1_SELECT"/>
+      </player>
+      <player number="2">
+        <control name="P2_BUTTON1" voice="Cross" alwaysActive="0" color="Blue" inputCodes="JOYCODE_2_BUTTON1"/>
+        <control name="P2_BUTTON2" voice="Circle" alwaysActive="0" color="Red" inputCodes="JOYCODE_2_BUTTON2"/>
+        <control name="P2_BUTTON3" voice="Triangle" alwaysActive="0" color="Green" inputCodes="JOYCODE_2_BUTTON3"/>
+        <control name="P2_BUTTON4" voice="Square" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_2_BUTTON4"/>
+        <control name="P2_BUTTON5" voice="R1" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON5"/>
+        <control name="P2_BUTTON6" voice="L1" alwaysActive="0" color="White" inputCodes="JOYCODE_2_BUTTON6"/>
+        <control name="P2_BUTTON7" voice="R2" alwaysActive="0" color="Brown" inputCodes="JOYCODE_2_BUTTON7"/>
+        <control name="P2_BUTTON8" voice="L2" alwaysActive="0" color="Brown" inputCodes="JOYCODE_2_BUTTON8"/>
+        <control name="P2_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_UP"/>
+        <control name="P2_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_DOWN"/>
+        <control name="P2_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_LEFT"/>
+        <control name="P2_JOYSTICK_RIGHT" voice="Right" alwaysActive="0" color="Black" inputCodes="JOYCODE_2_RIGHT"/>
+        <control name="P2_BUTTON9" voice="Start" alwaysActive="0" color="Lime" inputCodes="JOYCODE_2_START"/>
+        <control name="P2_BUTTON10" voice="Select" alwaysActive="0" color="Orange" inputCodes="JOYCODE_2_SELECT"/>
+      </player>
     </controlGroup>
     <controlGroup groupName="crash_bandicoot_2_-_cortex_strikes_back_(usa)" voice="Crash Bandicoot 2 - Cortex Strikes Back (USA)" numPlayers="1" alternating="0" jukebox="0">
       <player number="1">
@@ -254,8 +285,8 @@
         <control name="P1_BUTTON3" voice="Triangle" alwaysActive="0" color="Green" inputCodes="JOYCODE_1_BUTTON3"/>
         <control name="P1_BUTTON4" voice="Square" alwaysActive="0" color="Magenta" inputCodes="JOYCODE_1_BUTTON4"/>
         <control name="P1_BUTTON5" voice="R1" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON5"/>
-        <control name="P1_BUTTON6" voice="L1" alwaysActive="0" color="Brown" inputCodes="JOYCODE_1_BUTTON6"/>
-        <control name="P1_BUTTON7" voice="R2" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON7"/>
+        <control name="P1_BUTTON6" voice="L1" alwaysActive="0" color="White" inputCodes="JOYCODE_1_BUTTON6"/>
+        <control name="P1_BUTTON7" voice="R2" alwaysActive="0" color="Brown" inputCodes="JOYCODE_1_BUTTON7"/>
         <control name="P1_JOYSTICK_UP" voice="Up" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_UP"/>
         <control name="P1_JOYSTICK_DOWN" voice="Down" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_DOWN"/>
         <control name="P1_JOYSTICK_LEFT" voice="Left" alwaysActive="0" color="Black" inputCodes="JOYCODE_1_LEFT"/>

--- a/plugins/LEDBlinky/LEDBlinkyControls.xml
+++ b/plugins/LEDBlinky/LEDBlinkyControls.xml
@@ -249,7 +249,7 @@
       </player>
     </controlGroup>
   </emulator>
-  <emulator emuname="Super_Nintendo_Entertainment_System" emuDesc="" romDefaultNameVoice="0" ignoreGameQuitCommand="0" emulatorIsMAME="0">
+  <emulator emuname="Super_Nintendo_Entertainment_System" emuDesc="SNES Console" romDefaultNameVoice="0" ignoreGameQuitCommand="0" emulatorIsMAME="0">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
       <player number="0">
         <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
@@ -287,7 +287,7 @@
       </player>
     </controlGroup>
   </emulator>
-   <emulator emuname="Sega_Dreamcast" emuDesc="Sega Dreamcast">
+   <emulator emuname="Sega_Dreamcast" emuDesc="Sega Dreamcast Console">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
       <player number="0">
         <control name="CONTROL_JOY8WAY" voice="XBOX 3 60 Controller" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
@@ -325,7 +325,7 @@
       </player>
     </controlGroup>
   </emulator>
-  <emulator emuname="Sega_CD" emuDesc="Sega CD">
+  <emulator emuname="Sega_CD" emuDesc="Sega CD Console">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
       <player number="0">
         <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
@@ -363,7 +363,7 @@
       </player>
     </controlGroup>
   </emulator>
-  <emulator emuname="Sega_Genesis" emuDesc="Sega Genesis / Megadrive">
+  <emulator emuname="Sega_Genesis" emuDesc="Sega Genesis / Megadrive Console">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
       <player number="0">
         <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
@@ -401,7 +401,7 @@
       </player>
     </controlGroup>
   </emulator>
-  <emulator emuname="Sony_Playstation" emuDesc="PSX">
+  <emulator emuname="Sony_Playstation" emuDesc="PSX Console">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="2" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
       <player number="0">
         <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>
@@ -501,7 +501,7 @@
       </player>
     </controlGroup>
   </emulator>
-  <emulator emuname="Sony_PSP" emuDesc="PSP">
+  <emulator emuname="Sony_PSP" emuDesc="PSP Console">
     <controlGroup groupName="DEFAULT" voice="" numPlayers="1" alternating="0" defaultActive="48,48,48,48" defaultInactive="0,0,0,0" jukebox="0" ledwizGlobalPulse="3">
       <player number="0">
         <control name="CONTROL_JOY8WAY" voice="8-Way Joystick" primaryControl="1" alwaysActive="0" color="0,0,0" inputCodes=""/>

--- a/plugins/ledblinky-integration/C64.bat
+++ b/plugins/ledblinky-integration/C64.bat
@@ -6,7 +6,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% MAME
+  start "" LEDBlinky.exe %rom_name% Commodore_64
 )
 
 cd..\..\emulators\mame

--- a/plugins/ledblinky-integration/DC.bat
+++ b/plugins/ledblinky-integration/DC.bat
@@ -5,7 +5,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% RETROARCH
+  start "" LEDBlinky.exe %rom_name% Sega_Dreamcast
 )
 
 cd..\..\emulators\RetroArchXiso

--- a/plugins/ledblinky-integration/Dolphin.bat
+++ b/plugins/ledblinky-integration/Dolphin.bat
@@ -5,7 +5,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% RETROARCH
+  start "" LEDBlinky.exe %rom_name% Nintendo_GameCube
 )
 
 cd..\..\emulators\RetroArchXiso

--- a/plugins/ledblinky-integration/Genesis.bat
+++ b/plugins/ledblinky-integration/Genesis.bat
@@ -5,7 +5,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% MAME
+  start "" LEDBlinky.exe %rom_name% Sega_Genesis
 )
 
 cd..\..\emulators\MAME

--- a/plugins/ledblinky-integration/N64.bat
+++ b/plugins/ledblinky-integration/N64.bat
@@ -5,7 +5,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% RETROARCH
+  start "" LEDBlinky.exe %rom_name% Nintendo_64
 )
 
 cd..\..\emulators\RetroArchXiso

--- a/plugins/ledblinky-integration/PSP.bat
+++ b/plugins/ledblinky-integration/PSP.bat
@@ -5,7 +5,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% RETROARCH
+  start "" LEDBlinky.exe %rom_name% Sony_PSP
 )
 
 cd..\..\emulators\RetroArchXiso

--- a/plugins/ledblinky-integration/PSX.bat
+++ b/plugins/ledblinky-integration/PSX.bat
@@ -5,7 +5,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% MAME
+  start "" LEDBlinky.exe %rom_name% Sony_Playstation
 )
 
 cd..\..\emulators\MAME

--- a/plugins/ledblinky-integration/SNES.bat
+++ b/plugins/ledblinky-integration/SNES.bat
@@ -5,7 +5,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% MAME
+  start "" LEDBlinky.exe %rom_name% Super_Nintendo_Entertainment_System
 )
 
 cd..\..\emulators\mame

--- a/plugins/ledblinky-integration/SNESalt.bat
+++ b/plugins/ledblinky-integration/SNESalt.bat
@@ -5,7 +5,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% MAME
+  start "" LEDBlinky.exe %rom_name% Super_Nintendo_Entertainment_System
 )
 
 cd..\..\emulators\mame

--- a/plugins/ledblinky-integration/SegaCD.bat
+++ b/plugins/ledblinky-integration/SegaCD.bat
@@ -6,7 +6,7 @@ set rom_name=%2
 
 cd..\LEDBlinky
 if %is_ledblinky_activated%==1 (
-  start "" LEDBlinky.exe %rom_name% MAME
+  start "" LEDBlinky.exe %rom_name% Sega_CD
 )
 
 cd..\..\emulators\mame


### PR DESCRIPTION
Add color mapping for:

- C64: Uridium
- Sega CD: default
- Genesis: default
- N64: default
- DreamCast: default
- GameCube: default
- SNES: default
- PSX: default + Crash Bandicoot 2 + Castlevania - Symphony Of The Night + Tekken 3
- PSP: default